### PR TITLE
support for missing path to default

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -148,7 +148,7 @@ module.exports = function Configurator(logger, events) {
         protocol: parsed.protocol || 'amqp://',
         user: parsed.auth && parsed.auth.indexOf(':') !== -1 ? unescape(parsed.auth.split(':')[0]) : 'guest',
         pass: parsed.auth && parsed.auth.indexOf(':') !== -1 ? unescape(parsed.auth.split(':')[1]) : 'guest',
-        vhost: parsed.path.substring(1)
+        vhost: parsed.path && parsed.path.substring(1)
       };
     }
     let connection = Connection(options, logger.withNamespace('connection'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leisurelink/magicbus",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A message bus framework using RabbitMQ.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
upgraded a project to v2 using our previous url of "amqp://docker.dev:5672"... without the path the config option crashes on .substring